### PR TITLE
fix typos in ICES fish stomach contents use case

### DIFF
--- a/organism_interaction/ICESFishStomachContents/load_input_ices_fish_stomachs.sql
+++ b/organism_interaction/ICESFishStomachContents/load_input_ices_fish_stomachs.sql
@@ -7,8 +7,8 @@ SET CONSTRAINTS ALL DEFERRED;
 -- Note that the input data PredatorInformation.csv has malformed lines with unescaped double quotes. These have to be fixed before copying into psql.
 \copy public.predator_info FROM './input_data/PredatorInformation_fixed.csv' WITH (FORMAT csv, HEADER true, DELIMITER ',', QUOTE '"')
 \copy public.prey_info FROM './input_data/PreyInformation.csv' WITH (FORMAT CSV, HEADER);
-\copy public.input_event FROM './input_data/event.txt' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
-\copy public.input_occurrence FROM './input_data/occurrence.txt' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
-\copy public.emof FROM './input_data/extendedmeasurementorfact.txt' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
+\copy public.input_event FROM './input_data/event.csv' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
+\copy public.input_occurrence FROM './input_data/occurrence.csv' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
+\copy public.emof FROM './input_data/extendedmeasurementorfact.csv' WITH (DELIMITER E'\t', FORMAT CSV, HEADER);
 
 COMMIT;

--- a/organism_interaction/ICESFishStomachContents/schema_input_ices_fish_stomachs.sql
+++ b/organism_interaction/ICESFishStomachContents/schema_input_ices_fish_stomachs.sql
@@ -2,7 +2,7 @@
 -- Schema for input data to be mapped to dwc-dp publishing model.
 --
 
-Not yet configured
+-- Not yet configured
 
 -- From the original data set: https://datsu.ices.dk/web/selRep.aspx?Dataset=157
 CREATE TABLE file_info (


### PR DESCRIPTION
- comment a line that is supposed to be comment
- fix file extension typo